### PR TITLE
docs: correct README wording and clarify PR message confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,184 @@ When complete, you'll be able to grab random quotes from the command line, like 
 ## Start the Tutorial
 
 You can find your next step in [this repo's issues](../../issues/)!
+
+## Beginner Guide: Connect to Local MSSQL + Natural Language Queries
+
+If you're new to this, think about it in **two layers**:
+
+1. **Database connectivity** (ODBC): your app can connect to SQL Server.
+2. **Natural language layer** (LLM): translates plain English into SQL, runs it, then explains results.
+
+OpenAI (or any LLM) does **not** directly "read" your database objects by itself. Your application must:
+
+* connect to MSSQL,
+* fetch schema metadata (tables/columns),
+* pass that schema context to the model,
+* execute generated SQL safely.
+
+### 1) Install prerequisites
+
+#### SQL Server + ODBC driver
+
+* Ensure your SQL Server instance is running locally.
+* Install an ODBC Driver for SQL Server (typically **ODBC Driver 18 for SQL Server**).
+
+#### Python packages
+
+Create a virtual environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install pyodbc sqlalchemy openai python-dotenv
+```
+
+### 2) Build your ODBC connection string
+
+For local SQL Server with username/password:
+
+```text
+DRIVER={ODBC Driver 18 for SQL Server};
+SERVER=localhost,1433;
+DATABASE=YourDatabaseName;
+UID=YourUser;
+PWD=YourPassword;
+TrustServerCertificate=yes;
+Encrypt=yes;
+```
+
+For Windows integrated auth, use:
+
+```text
+Trusted_Connection=yes;
+```
+
+Store secrets in `.env` (never commit real passwords):
+
+```env
+MSSQL_ODBC_CONN_STR=DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1433;DATABASE=YourDatabaseName;UID=YourUser;PWD=YourPassword;TrustServerCertificate=yes;Encrypt=yes;
+OPENAI_API_KEY=your_key_here
+```
+
+### 3) Test the MSSQL connection first
+
+Use this minimal script to verify connectivity:
+
+```python
+import os
+import pyodbc
+from dotenv import load_dotenv
+
+load_dotenv()
+conn_str = os.environ["MSSQL_ODBC_CONN_STR"]
+
+with pyodbc.connect(conn_str) as conn:
+    cur = conn.cursor()
+    cur.execute("SELECT TOP 1 name FROM sys.tables ORDER BY name")
+    row = cur.fetchone()
+    print("Connected. Example table:", row[0] if row else "No tables found")
+```
+
+If this fails, fix connection/driver/auth issues before touching the LLM layer.
+
+### 4) Provide schema context to the model
+
+Before asking for SQL generation, collect schema metadata such as:
+
+* table names,
+* column names and types,
+* relationships/foreign keys.
+
+You can query SQL Server system views like `INFORMATION_SCHEMA.TABLES` and `INFORMATION_SCHEMA.COLUMNS`.
+
+### 5) Safe natural language query flow
+
+Recommended flow:
+
+1. User asks a question in English.
+2. Your app sends the question + schema context to the model.
+3. Model returns a **read-only SQL query**.
+4. Your app validates SQL safety (allow only `SELECT`, no `INSERT/UPDATE/DELETE/DROP`).
+5. Execute query via ODBC.
+6. Send rows back to model for a plain-English explanation.
+
+### 6) Important safety rules (especially for novices)
+
+* Use a **read-only DB user** for LLM-generated queries.
+* Add server-side query timeout limits.
+* Limit returned row counts (`TOP 100`, pagination).
+* Log generated SQL for review.
+* Start with a non-production database.
+
+### 7) Minimal architecture you can build next
+
+* `db.py` — ODBC connect + schema fetch + SQL execution
+* `llm.py` — prompt creation + OpenAI call
+* `app.py` — CLI loop: ask question -> generate SQL -> validate -> run -> summarize
+
+---
+
+The prototype described above has now been added directly in this repository (see the section below).
+
+## Run a working prototype in this repo
+
+I added a minimal command-line prototype:
+
+* `db.py` — connection, schema loading, query execution
+* `llm.py` — SQL generation, SELECT-only validation, explanation
+* `app.py` — interactive CLI loop
+
+### Quick start
+
+1. Install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install pyodbc openai python-dotenv
+```
+
+2. Add `.env` in the repository root. You can choose **either** style:
+
+**Style A: one full connection string**
+
+```env
+MSSQL_ODBC_CONN_STR=DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1433;DATABASE=YourDatabaseName;UID=YourUser;PWD=YourPassword;TrustServerCertificate=yes;Encrypt=yes;
+OPENAI_API_KEY=your_key_here
+OPENAI_MODEL=gpt-4o-mini
+DB_QUERY_TIMEOUT_SECONDS=30
+```
+
+**Style B: split values (easier for beginners)**
+
+```env
+MSSQL_ODBC_DRIVER=ODBC Driver 18 for SQL Server
+MSSQL_SERVER=localhost,1433
+MSSQL_DATABASE=YourDatabaseName
+MSSQL_UID=YourUser
+MSSQL_PWD=YourPassword
+MSSQL_ENCRYPT=yes
+MSSQL_TRUST_SERVER_CERT=yes
+OPENAI_API_KEY=your_key_here
+OPENAI_MODEL=gpt-4o-mini
+DB_QUERY_TIMEOUT_SECONDS=30
+```
+
+> Yes — the ODBC driver name goes in `MSSQL_ODBC_DRIVER` (Style B) or inside `DRIVER={...}` in `MSSQL_ODBC_CONN_STR` (Style A).
+
+3. Run the assistant:
+
+```bash
+python app.py
+```
+
+4. Ask questions in plain English, for example:
+
+* "Show the top 10 orders by total amount"
+* "How many users signed up this month?"
+
+### Important notes
+
+* This prototype is intentionally **read-only** and blocks dangerous SQL keywords.
+* Use a read-only SQL login whenever possible.
+* Results are capped (fetches up to 100 rows per query).

--- a/app.py
+++ b/app.py
@@ -1,0 +1,57 @@
+"""CLI app: ask natural-language questions against local MSSQL safely."""
+
+from __future__ import annotations
+
+from dotenv import load_dotenv
+
+from db import DatabaseError, fetch_schema_context, run_select_query
+from llm import LLMError, explain_results, generate_sql
+
+
+def main() -> None:
+    load_dotenv()
+    print("Natural Language SQL Assistant (MSSQL)")
+    print("Type 'exit' to quit.\n")
+
+    try:
+        schema_context = fetch_schema_context()
+    except DatabaseError as exc:
+        print(f"Database setup error: {exc}")
+        return
+
+    print("Schema loaded. You can now ask questions like:")
+    print("  - 'Show top 10 customers by total spend this year'\n")
+
+    while True:
+        question = input("Question> ").strip()
+        if question.lower() in {"exit", "quit"}:
+            print("Goodbye!")
+            break
+        if not question:
+            continue
+
+        try:
+            sql = generate_sql(question, schema_context)
+            print(f"\nGenerated SQL:\n{sql}\n")
+
+            result = run_select_query(sql, max_rows=100)
+            rows = result["rows"]
+
+            print(f"Rows returned: {result['row_count']}")
+            if rows:
+                print("First row:")
+                print(rows[0])
+            else:
+                print("No rows matched.")
+
+            explanation = explain_results(question, sql, rows)
+            print("\nExplanation:")
+            print(explanation)
+            print("\n" + "-" * 60 + "\n")
+
+        except (LLMError, DatabaseError) as exc:
+            print(f"Error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/db.py
+++ b/db.py
@@ -1,0 +1,132 @@
+"""Database helpers for MSSQL ODBC access.
+
+This module is intentionally beginner-friendly and focused on read-only querying.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pyodbc
+
+
+class DatabaseError(RuntimeError):
+    """Raised when database configuration or execution fails."""
+
+
+def _build_conn_str_from_parts() -> str | None:
+    """Build a connection string from individual env vars when provided.
+
+    This is a beginner-friendly alternative to setting one long
+    `MSSQL_ODBC_CONN_STR` value.
+    """
+    driver = os.getenv("MSSQL_ODBC_DRIVER")
+    server = os.getenv("MSSQL_SERVER")
+    database = os.getenv("MSSQL_DATABASE")
+
+    if not (driver and server and database):
+        return None
+
+    parts = [
+        f"DRIVER={{{driver}}}",
+        f"SERVER={server}",
+        f"DATABASE={database}",
+        f"Encrypt={os.getenv('MSSQL_ENCRYPT', 'yes')}",
+        f"TrustServerCertificate={os.getenv('MSSQL_TRUST_SERVER_CERT', 'yes')}",
+    ]
+
+    if os.getenv("MSSQL_TRUSTED_CONNECTION", "no").lower() in {"yes", "true", "1"}:
+        parts.append("Trusted_Connection=yes")
+    else:
+        uid = os.getenv("MSSQL_UID")
+        pwd = os.getenv("MSSQL_PWD")
+        if not (uid and pwd):
+            raise DatabaseError(
+                "Using split MSSQL settings requires MSSQL_UID and MSSQL_PWD, "
+                "unless MSSQL_TRUSTED_CONNECTION=yes."
+            )
+        parts.append(f"UID={uid}")
+        parts.append(f"PWD={pwd}")
+
+    return ";".join(parts) + ";"
+
+
+def get_connection() -> pyodbc.Connection:
+    """Create and return a pyodbc connection using env configuration.
+
+    Supported config styles:
+      1) MSSQL_ODBC_CONN_STR (single full connection string)
+      2) Split env vars (driver/server/database/etc.)
+
+    Optional:
+      - DB_QUERY_TIMEOUT_SECONDS (default: 30)
+    """
+    conn_str = os.getenv("MSSQL_ODBC_CONN_STR") or _build_conn_str_from_parts()
+    if not conn_str:
+        raise DatabaseError(
+            "Set either MSSQL_ODBC_CONN_STR, or split vars: "
+            "MSSQL_ODBC_DRIVER, MSSQL_SERVER, MSSQL_DATABASE, "
+            "plus MSSQL_UID/MSSQL_PWD (or MSSQL_TRUSTED_CONNECTION=yes)."
+        )
+
+    timeout_seconds = int(os.getenv("DB_QUERY_TIMEOUT_SECONDS", "30"))
+    try:
+        conn = pyodbc.connect(conn_str, timeout=timeout_seconds)
+    except pyodbc.Error as exc:
+        raise DatabaseError(f"Could not connect to SQL Server: {exc}") from exc
+
+    return conn
+
+
+def fetch_schema_context(limit_tables: int = 25, limit_columns: int = 400) -> str:
+    """Return a compact schema summary to send to the LLM."""
+    table_sql = """
+        SELECT TOP (?) TABLE_SCHEMA, TABLE_NAME
+        FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_TYPE = 'BASE TABLE'
+        ORDER BY TABLE_SCHEMA, TABLE_NAME;
+    """
+
+    column_sql = """
+        SELECT TOP (?) TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE
+        FROM INFORMATION_SCHEMA.COLUMNS
+        ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION;
+    """
+
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(table_sql, limit_tables)
+        tables = cur.fetchall()
+
+        cur.execute(column_sql, limit_columns)
+        columns = cur.fetchall()
+
+    table_lines = [f"- {row.TABLE_SCHEMA}.{row.TABLE_NAME}" for row in tables]
+    column_lines = [
+        f"- {row.TABLE_SCHEMA}.{row.TABLE_NAME}.{row.COLUMN_NAME} ({row.DATA_TYPE})"
+        for row in columns
+    ]
+
+    return "\n".join(
+        [
+            "TABLES:",
+            *(table_lines or ["- (none found)"]),
+            "",
+            "COLUMNS:",
+            *(column_lines or ["- (none found)"]),
+        ]
+    )
+
+
+def run_select_query(sql: str, max_rows: int = 100) -> dict[str, Any]:
+    """Execute a validated SELECT query and return rows as dictionaries."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(sql)
+
+        columns = [col[0] for col in cur.description] if cur.description else []
+        rows = cur.fetchmany(max_rows)
+
+    data = [dict(zip(columns, row)) for row in rows]
+    return {"columns": columns, "rows": data, "row_count": len(data)}

--- a/llm.py
+++ b/llm.py
@@ -1,0 +1,109 @@
+"""LLM helpers for natural-language-to-SQL and results explanation."""
+
+from __future__ import annotations
+
+import os
+import re
+
+from openai import OpenAI
+
+
+class LLMError(RuntimeError):
+    """Raised when the model returns invalid SQL or malformed output."""
+
+
+FORBIDDEN_SQL_PATTERNS = [
+    r"\binsert\b",
+    r"\bupdate\b",
+    r"\bdelete\b",
+    r"\bdrop\b",
+    r"\balter\b",
+    r"\bcreate\b",
+    r"\btruncate\b",
+    r"\bmerge\b",
+    r"\bexec\b",
+    r"\bexecute\b",
+]
+
+
+def _client() -> OpenAI:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise LLMError("OPENAI_API_KEY is not set. Add it to your .env file first.")
+    return OpenAI(api_key=api_key)
+
+
+def validate_select_only_sql(sql: str) -> str:
+    """Allow only a single SELECT statement (or CTE + SELECT)."""
+    normalized = sql.strip().strip("`").strip()
+    lower = normalized.lower()
+
+    if not lower:
+        raise LLMError("Model returned empty SQL.")
+
+    if ";" in lower[:-1]:
+        raise LLMError("Multiple SQL statements are not allowed.")
+
+    if not (lower.startswith("select") or lower.startswith("with")):
+        raise LLMError("Only SELECT queries are allowed.")
+
+    for pattern in FORBIDDEN_SQL_PATTERNS:
+        if re.search(pattern, lower):
+            raise LLMError(f"Forbidden SQL operation detected: {pattern}")
+
+    return normalized.rstrip(";")
+
+
+def generate_sql(question: str, schema_context: str) -> str:
+    """Generate read-only SQL from a user question and schema context."""
+    model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+
+    system_prompt = (
+        "You are a SQL Server assistant. Return exactly one read-only SQL query. "
+        "Output SQL text only, no markdown and no explanation. "
+        "Rules: only SELECT/CTE statements, include TOP 100 unless user asks for fewer."
+    )
+
+    user_prompt = (
+        f"Question:\n{question}\n\n"
+        f"Schema context:\n{schema_context}\n\n"
+        "Return one SQL Server query now."
+    )
+
+    response = _client().responses.create(
+        model=model,
+        input=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+    )
+
+    sql = (response.output_text or "").strip()
+    return validate_select_only_sql(sql)
+
+
+def explain_results(question: str, query: str, rows: list[dict]) -> str:
+    """Turn query results into a concise, beginner-friendly explanation."""
+    model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    sample_rows = rows[:10]
+
+    system_prompt = (
+        "You explain SQL query results clearly for a beginner. "
+        "Be concise and mention if results are truncated."
+    )
+    user_prompt = (
+        f"Original question: {question}\n"
+        f"SQL used: {query}\n"
+        f"Sample rows (max 10): {sample_rows}\n"
+        f"Total rows returned to app: {len(rows)}"
+    )
+
+    response = _client().responses.create(
+        model=model,
+        input=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+    )
+
+    return (response.output_text or "").strip()


### PR DESCRIPTION
### Motivation
- Remove an outdated README sentence that implied the prototype still needed to be added so PR/commit titles like `fix: clarify ODBC driver env and support split MSSQL settings` do not cause confusion about branch state.

### Description
- Update `README.md` to replace the misleading "next step" wording with a short confirmation that the minimal prototype is already included in the repository and keep explicit guidance that the ODBC driver name belongs in `MSSQL_ODBC_DRIVER` (or inside `DRIVER={...}` in `MSSQL_ODBC_CONN_STR`).

### Testing
- Ran `python -m py_compile app.py db.py llm.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69909b40703c8329a759ea6269fe9e2f)